### PR TITLE
wcs_warden duration

### DIFF
--- a/addons/source-python/plugins/wcs/core/helpers/esc/commands.py
+++ b/addons/source-python/plugins/wcs/core/helpers/esc/commands.py
@@ -2010,7 +2010,7 @@ def wcs_regeneration_command(command_info, player:convert_userid_to_player, valu
 
 
 @TypedServerCommand('wcs_warden')
-def wcs_warden_command(command_info, wcsplayer:convert_userid_to_wcsplayer, duration:int, damage:int, radius:float, team_target:int, team_target_name:deprecated, x:float, y:float, z:float, round:deprecated):
+def wcs_warden_command(command_info, wcsplayer:convert_userid_to_wcsplayer, duration:float, damage:int, radius:float, team_target:int, team_target_name:deprecated, x:float, y:float, z:float, round:deprecated):
     if wcsplayer is None:
         return
 

--- a/addons/source-python/plugins/wcs/core/helpers/wards.py
+++ b/addons/source-python/plugins/wcs/core/helpers/wards.py
@@ -218,7 +218,7 @@ class _WardManager(AutoUnload, list):
 
                     ward.duration -= 1
 
-                    if not ward.duration:
+                    if ward.duration <= 0:
                         try:
                             ward.on_disappear()
                         except:


### PR DESCRIPTION
Changed the duration of wards to use float values instead of integer since some races use decimals for the duration of wards.
However I've tested this and although it works partially there's a part of the effect that will stay active indefinitely, not sure why.

Probably need to alter something in wards.py to make it work properly.