### PR TITLE
Wrong command has been used

### DIFF
--- a/addons/source-python/plugins/wcs/wcs.py
+++ b/addons/source-python/plugins/wcs/wcs.py
@@ -264,7 +264,7 @@ hinttext_cooldown_ready_message = HintText(menu_strings['hinttext_cooldown ready
 
 help_text_message.message.tokens['command'] = COMMANDS['wcshelp'][0]
 welcome_text_message.message.tokens['command'] = COMMANDS['wcshelp'][0]
-skills_reset_message.message.tokens['command'] = COMMANDS['resetskills'][0]
+skills_reset_message.message.tokens['command'] = COMMANDS['spendskills'][0]
 
 _delays = defaultdict(set)
 _melee_weapons = [weapon.basename for weapon in WeaponClassIter('melee')]


### PR DESCRIPTION
Changed "resetskills" to "spendskills" in order to have the proper message after you use the command "resetskills".

Before: [WCS] Your skills has been reset. Type 'resetskills' to spend your 18 unused skill points.
 -> 
After: [WCS] Your skills has been reset. Type 'spendskills' to spend your 18 unused skill points.

PS: Has been tested.