### PR TITLE
Fixed exception with rcon say command

### DIFF
--- a/addons/source-python/plugins/wcs/wcs.py
+++ b/addons/source-python/plugins/wcs/wcs.py
@@ -828,6 +828,9 @@ def player_death(event):
 @Event('player_say')
 def player_say(event):
     userid = event['userid']
+    if userid == 0:
+        return # The server is not a player :)
+        
     wcsplayer = Player.from_userid(userid)
 
     if wcsplayer.ready:


### PR DESCRIPTION
WCS would throw an exception when using the say command with rcon.
Exception ->"ValueError: Conversion from "Userid" (0) to "Index" failed."

Thanks to @Xiazee for fixing this issue.

- Has been tested and works as intended.