### PR TITLE
Fix translations strings getting values baked in by _format_message

### DIFF
--- a/addons/source-python/plugins/wcs/core/helpers/esc/commands.py
+++ b/addons/source-python/plugins/wcs/core/helpers/esc/commands.py
@@ -307,6 +307,8 @@ def _format_message(userid, name, args):
     if text is None:
         return tuple(), None
 
+    text = text.copy()  # Make sure we do not modify the original strings
+
     if args:
         tokens = {}
 


### PR DESCRIPTION
The tokens would be replaced the first time the string is used, meaning the same values would appear each subsequent time.