### PR TITLE
Removed: Logging Code & Fixed server crashes

### DIFF
--- a/addons/source-python/plugins/wcs/wcs.py
+++ b/addons/source-python/plugins/wcs/wcs.py
@@ -992,19 +992,6 @@ def on_level_init(map_name):
     item_manager._refresh_config.clear()
 
 
-# Is ESC supported?
-if IS_ESC_SUPPORT_ENABLED:
-    #  Used to clean up loading/unloading of wcs
-    @OnServerOutput
-    def on_server_output(severity, msg):
-        if msg.startswith(('[EventScripts] Loaded wcs/modules/races/', 'Unloading wcs/modules/races/')) or (msg.startswith('wcs/modules/races/') and msg.endswith(' has been unloaded\n')):
-            return OutputReturn.BLOCK
-        if msg.startswith(('[EventScripts] Loaded wcs/modules/items/', 'Unloading wcs/modules/items/')) or (msg.startswith('wcs/modules/items/') and msg.endswith(' has been unloaded\n')):
-            return OutputReturn.BLOCK
-
-        return OutputReturn.CONTINUE
-
-
 # TODO: Should probably find a less demanding solution
 @OnTick
 def on_tick():


### PR DESCRIPTION
Removed some code from wcs.py that was used for logging purposes, but this code would also cause the modification to become unusable as it would bring a lot of instability with it causing a major amount of server crashes. 
Removing this code snippet makes the entire modification stable.