### PR TITLE
Added: Level Up Sound & Config

### DIFF
--- a/addons/source-python/plugins/wcs/core/config/__init__.py
+++ b/addons/source-python/plugins/wcs/core/config/__init__.py
@@ -44,6 +44,7 @@ __all__ = (
     'cfg_welcome_text',
     'cfg_new_player_bank_bonus',
     'cfg_debug_alias_duplicate',
+    'cfg_level_up_sound'
     'cfg_level_up_effect',
     'cfg_rank_gain_effect',
     'cfg_rested_xp_gained_base',
@@ -97,6 +98,7 @@ with ConfigManager(f'{info.name}/config.cfg', cvar_prefix=f'{info.name}_') as co
     cfg_welcome_gui_text = config.cvar('welcome_gui_text', '0', config_strings['welcome_gui_text'])
     cfg_new_player_bank_bonus = config.cvar('new_player_bank_bonus', '15', config_strings['new_player_bank_bonus'])
     cfg_debug_alias_duplicate = config.cvar('debug_alias_duplicate', '1', config_strings['debug_alias_duplicate'])
+    cfg_level_up_sound = config.cvar('level_up_sound', '0', config_strings['level_up_sound'])
     cfg_level_up_effect = config.cvar('level_up_effect', '1', config_strings['level_up_effect'])
     cfg_rank_gain_effect = config.cvar('rank_gain_effect', '1', config_strings['rank_gain_effect'])
     cfg_spawn_text = config.cvar('spawn_text', '1', config_strings['spawn_text'])

--- a/addons/source-python/plugins/wcs/wcs.py
+++ b/addons/source-python/plugins/wcs/wcs.py
@@ -1135,6 +1135,18 @@ def on_player_level_up(wcsplayer, race, old_level):
                     _delays[wcsplayer].add(delay)
                     break
 
+        if cfg_level_up_sound.get_int():
+            player = wcsplayer.player
+
+            ##The new level up sound which is part of the Eventscripts Emulator that is modified for Warcraft-Source
+            ## - https://github.com/ManifestManah/EventScripts-Emulator-For-WCS/tree/master/sound/wcs
+            if SOURCE_ENGINE_BRANCH == 'csgo':
+                player.play_sound('wcs/levelup.mp3')
+            
+            ##The level up sound that was originally used in the older versions of Warcraft-Source
+            if SOURCE_ENGINE_BRANCH == 'css':
+                player.play_sound('ambient/machines/teleport1.wav')
+
         if cfg_level_up_effect.get_int():
             player = wcsplayer.player
 

--- a/resource/source-python/translations/wcs/config_strings.ini
+++ b/resource/source-python/translations/wcs/config_strings.ini
@@ -175,6 +175,9 @@
     nl = "Toont bij het laden een waarschuwing voor rassen/items die gecodeerd zijn via de oude stijl en een duplicate racealias bevatten (0 = uitschakelen, 1 = inschakelen)"
     pt-br = "Mostra uma mensagem de aviso para raças/items antigos se eles registrarem um pseudônimo já registrado carregado (0 = desligado; 1 = ligado)"
     fr = "Montre un message d'alerte (toggle) pour les anciens modeles de races et d'objets si ils sont déjà enrengistrés lors du lancement"
+[level_up_sound]
+    en = "Should a sound be played for the player when he levels up his race? (OBS: Requires Modified Eventscripts Emulator for WC:S to be installed)"
+    da = "Skal en lyd afspilles for spilleren når han stiger et level? (OBS: dette Kræver at Modified Eventscripts Emulator for WC:S er installeret) (0 = slået fra, 1 = slået til)"
 [level_up_effect]
     en = "An effect which is shown at a player when they level up their race"
     ru = "Эффект, который отображается у игрока при повышении уровня его расы"


### PR DESCRIPTION
Added the necessary code that will allow players to hear a sound when they level up. For nostalgic purposes the CS:S uses the old level up sound effect.

Also added a configuration option which lets server owners enable / disable this feature in the csgo/cfg/source-python/wcs/config.cfg file. The level up sound effect is disabled by default as it requires the Modified Eventscripts Emulator for WC:S to be installed on the server in order to work for CS:GO.