### PR TITLE
Fixed: Danish Cooldown Chat Message

### DIFF
--- a/resource/source-python/translations/wcs/chat_strings.ini
+++ b/resource/source-python/translations/wcs/chat_strings.ini
@@ -352,7 +352,7 @@
     en = "{lightgreen}Cooldown time is {green}{cooldown:.1f}{lightgreen} second(s), {green}{left:.1f}{lightgreen} left."
     ru = "{lightgreen}Время перезарядки {green}{cooldown:.1f}{lightgreen} сек., осталось {green}{left:.1f}{lightgreen}."
     fi = "{lightgreen}Odotus aika on {green}{cooldown:.1f}{lightgreen} sekuntia, {green}{left:.1f}{lightgreen} jäljellä."
-    da = "{lightgreen}Din ability's cooldown har{green}{cooldown:.1f}{lightgreen} sekund(er), {green}{left:.1f}{lightgreen} tilbage."
+    da = "{lightgreen}Din ability's cooldown har{green} {cooldown:.1f}{lightgreen} sekund(er), {green}{left:.1f}{lightgreen} tilbage."
     de = "{lightgreen}Cooldown übrig: {green}{left:.1f}{lightgreen} - Cooldown beträgt: {green}{cooldown:.1f}{lightgreen} Sekunde(n)."
     nl = "{lightgreen}De cooldown van je ability is {green}{cooldown:.1f}{lightgreen} second(en), {green}{left:.1f}{lightgreen} over."
     pt-br = "{lightgreen}Tempo de recarga é de {green}{cooldown:.1f}{lightgreen} segundo(s), {green}{left:.1f}{lightgreen} faltando."


### PR DESCRIPTION
Fixed a mistake with the Danish cooldown chat message, where the cooldown would be displayed right after a word without any spacings.