### PR TITLE
Make team limit code less likely to fail

### DIFF
--- a/addons/source-python/plugins/wcs/core/modules/races/manager.py
+++ b/addons/source-python/plugins/wcs/core/modules/races/manager.py
@@ -171,7 +171,7 @@ class RaceSetting(_BaseSetting):
 
                 # If FFA is enabled the limit is considered to be for all the players on the server
                 if ffa_enabled:
-                    limit = list(chain.from_iterable([team_data[i][f'_internal_{self.name}_limit_allowed'] for i in team_data]))
+                    limit = list(chain.from_iterable([team_data[i].get(f'_internal_{self.name}_limit_allowed', []) for i in team_data]))
                 else:
                     limit = team_data[team].get(f'_internal_{self.name}_limit_allowed', [])
 

--- a/addons/source-python/plugins/wcs/core/players/__init__.py
+++ b/addons/source-python/plugins/wcs/core/players/__init__.py
@@ -3,6 +3,8 @@
 # ============================================================================
 # >> IMPORTS
 # ============================================================================
+import warnings
+
 # Source.Python Imports
 from engines.server import engine_server
 from engines.server import global_vars
@@ -322,3 +324,35 @@ def _initialize(baseplayer):
             OnClientAuthorized.manager.notify(baseplayer)
 
         _bots.clear()
+
+
+def add_race_limit(team, race, userid):
+    key = f'_internal_{race}_limit_allowed'
+
+    if key not in team_data[team]:
+        team_data[team][key] = []
+
+    team_data[team][key].append(userid)
+
+
+def remove_race_limit(team, race, userid):
+    key = f'_internal_{race}_limit_allowed'
+
+    try:
+        team_data[team][key].remove(userid)
+
+        if not team_data[team][key]:
+            del team_data[team][key]
+
+    except KeyError as e:
+        # Try the other team TODO: does this work in other games?
+        try:
+            other_team = 5-team
+            team_data[other_team][key].remove(userid)
+
+            if not team_data[other_team][key]:
+                del team_data[other_team][key]
+        except KeyError:
+            warnings.warn("Error while trying to remove userid:%s from teamlimit:\n %s" % (userid, e))
+        else:
+            warnings.warn("While removing userid:%s from teamlimit, they were found counting toward the enemy's limit" % (userid,))

--- a/addons/source-python/plugins/wcs/core/players/__init__.py
+++ b/addons/source-python/plugins/wcs/core/players/__init__.py
@@ -329,8 +329,6 @@ def _initialize(baseplayer):
 def add_race_limit(team, race, userid):
     race_key = f'_internal_{race}_limit_allowed'
 
-    # print("[DEBUG] add_race_limit t:%s %s u:%s" % (team, race, userid))
-
     if race_key not in team_data[team]:
         team_data[team][race_key] = []
 
@@ -344,8 +342,6 @@ def _remove_race_limit_key(team, race_key, userid):
 
 def remove_race_limit(team, race, userid):
     race_key = f'_internal_{race}_limit_allowed'
-
-    # print("[DEBUG] remove_race_limit t:%s %s u:%s" % (team, race, userid))
 
     try:
         _remove_race_limit_key(team, race_key, userid)
@@ -361,4 +357,4 @@ def remove_race_limit(team, race, userid):
                 )
                 break
         else:
-            warnings.warn("Could not remove userid:%s from teamlimit from any team:" % (userid,))
+            warnings.warn("Could not remove userid:%s from teamlimit for any team:\n %s" % (userid, e))

--- a/addons/source-python/plugins/wcs/core/players/__init__.py
+++ b/addons/source-python/plugins/wcs/core/players/__init__.py
@@ -329,6 +329,8 @@ def _initialize(baseplayer):
 def add_race_limit(team, race, userid):
     race_key = f'_internal_{race}_limit_allowed'
 
+    # print("[DEBUG] add_race_limit t:%s %s u:%s" % (team, race, userid))
+
     if race_key not in team_data[team]:
         team_data[team][race_key] = []
 
@@ -343,6 +345,8 @@ def _remove_race_limit_key(team, race_key, userid):
 def remove_race_limit(team, race, userid):
     race_key = f'_internal_{race}_limit_allowed'
 
+    # print("[DEBUG] remove_race_limit t:%s %s u:%s" % (team, race, userid))
+
     try:
         _remove_race_limit_key(team, race_key, userid)
 
@@ -352,9 +356,9 @@ def remove_race_limit(team, race, userid):
             if race_key in team_data[t] and userid in team_data[t][race_key]:
                 _remove_race_limit_key(t, race_key, userid)
                 warnings.warn(
-                    "While removing userid:%s from teamlimit, "
+                    "After failing to remove userid:%s from teamlimit, "
                     "they were found counting toward the enemy's (team:%s) limit" % (userid, t)
                 )
                 break
         else:
-            warnings.warn("Could not remove userid:%s from teamlimit for any team:" % (userid,))
+            warnings.warn("Could not remove userid:%s from teamlimit from any team:" % (userid,))

--- a/addons/source-python/plugins/wcs/core/players/__init__.py
+++ b/addons/source-python/plugins/wcs/core/players/__init__.py
@@ -344,7 +344,7 @@ def remove_race_limit(team, race, userid):
         if not team_data[team][key]:
             del team_data[team][key]
 
-    except KeyError as e:
+    except (KeyError, ValueError) as e:
         # Try the other team TODO: does this work in other games?
         try:
             other_team = 5-team
@@ -352,7 +352,7 @@ def remove_race_limit(team, race, userid):
 
             if not team_data[other_team][key]:
                 del team_data[other_team][key]
-        except KeyError:
+        except (KeyError, ValueError):
             warnings.warn("Error while trying to remove userid:%s from teamlimit:\n %s" % (userid, e))
         else:
             warnings.warn("While removing userid:%s from teamlimit, they were found counting toward the enemy's limit" % (userid,))

--- a/addons/source-python/plugins/wcs/core/players/entity.py
+++ b/addons/source-python/plugins/wcs/core/players/entity.py
@@ -106,7 +106,7 @@ from ..modules.races.manager import race_manager
 #   Players
 from . import BasePlayer
 from . import index_from_accountid
-from . import team_data
+from . import team_data, add_race_limit, remove_race_limit
 from . import set_weapon_name
 #   Ranks
 from ..ranks import rank_manager
@@ -464,12 +464,7 @@ class Player(object, metaclass=_PlayerMeta):
             team = self.player.team_index
 
             if team >= 2:
-                key = f'_internal_{self._current_race}_limit_allowed'
-
-                if key not in team_data[team]:
-                    team_data[team][key] = []
-
-                team_data[team][key].append(self.userid)
+                add_race_limit(team, self._current_race, self.userid)
 
             OnPlayerReady.manager.notify(self)
 
@@ -509,12 +504,7 @@ class Player(object, metaclass=_PlayerMeta):
                 team = self.player.team_index
 
                 if team >= 2:
-                    key = f'_internal_{self._current_race}_limit_allowed'
-
-                    if key not in team_data[team]:
-                        team_data[team][key] = []
-
-                    team_data[team][key].append(self.userid)
+                    add_race_limit(team, self._current_race, self.userid)
 
                 OnPlayerReady.manager.notify(self)
 
@@ -809,15 +799,8 @@ class Player(object, metaclass=_PlayerMeta):
         team = self.player.team
 
         if team >= 2:
-            team_data[team][f'_internal_{old}_limit_allowed'].remove(self.userid)
-
-            if not team_data[team][f'_internal_{old}_limit_allowed']:
-                del team_data[team][f'_internal_{old}_limit_allowed']
-
-            if f'_internal_{value}_limit_allowed' not in team_data[team]:
-                team_data[team][f'_internal_{value}_limit_allowed'] = []
-
-            team_data[team][f'_internal_{value}_limit_allowed'].append(self.userid)
+            remove_race_limit(team, old, self.userid)
+            add_race_limit(team, value, self.userid)
 
         _restrictions.player_restrictions[self.userid].clear()
 


### PR DESCRIPTION
Catches errors that might happen in case the player does not count towards the teamlimit of the team he is currently on. Instead of ~throwing~ raising an exception and failing to change the players race, it instead gives a warning and checks if the player was counting toward the enemy team's teamlimit for the current race.

These kinds of error may occur when other plugins/addons interfere with the related events as mentioned in #87. This is not enough to completely fix the mentioned issue.

Need to check if the code works as expected, and gives the expected warnings when used with Zombie Reloaded V3.