### PR TITLE
Fix numbering of skills in old style raceinfo

### DIFF
--- a/addons/source-python/plugins/wcs/core/menus/build.py
+++ b/addons/source-python/plugins/wcs/core/menus/build.py
@@ -526,11 +526,11 @@ def raceinfo_skills_single_menu_build(menu, client):
         else:
             option = PagedOption(settings.strings[name], name)
 
-        menu.append(option)
+        # Perform translation of the ultimate/ability part right now, so we can append the description.
+        option.text = option.text.get_string(get_client_language(client))
 
         if name == current_skill:
             kwargs = {}
-
             settings.execute('on_skill_desc', wcsplayer, name, kwargs)
 
             info = settings.strings[f'{name} description']
@@ -539,7 +539,10 @@ def raceinfo_skills_single_menu_build(menu, client):
                 info = info.get_string(get_client_language(client), **kwargs)
 
                 for text in wrap(info, 30):
-                    menu.append(text)
+                    option.text += '\n' + text
+
+        menu.append(option)
+
 
 
 @raceinfo_skills_detail_menu.register_build_callback


### PR DESCRIPTION
Fixes #90
Surprisingly simple to fix. But had to make sure the ultimate string was already evaluated before appending the description.
![image](https://user-images.githubusercontent.com/9294009/154808541-264236db-ba8f-4e04-8135-0a9c5d4abf80.png)
